### PR TITLE
Use ring buffer to avoid memory leak

### DIFF
--- a/Sources/CLI/AudioTee.swift
+++ b/Sources/CLI/AudioTee.swift
@@ -200,7 +200,7 @@ struct AudioTee {
 // Helper for stderr output
 var standardError = FileHandle.standardError
 
-extension FileHandle: @retroactive TextOutputStream {
+extension FileHandle: TextOutputStream {
   public func write(_ string: String) {
     let data = Data(string.utf8)
     self.write(data)

--- a/Sources/Core/AudioBuffer.swift
+++ b/Sources/Core/AudioBuffer.swift
@@ -2,17 +2,48 @@ import CoreAudio
 import Foundation
 
 public class AudioBuffer {
-  private var buffer = Data()
-  private let targetChunkDuration: Double
-  private let streamFormat: AudioStreamBasicDescription
+  private var buffer: [UInt8]
+  private var writeIndex: Int = 0
+  private var readIndex: Int = 0
+  private var availableBytes: Int = 0
+  private let maxBufferSize: Int
+  
+  // Pre-calculated values for efficiency
+  private let bytesPerChunk: Int
+  private let chunkDuration: Double
 
   public init(format: AudioStreamBasicDescription, chunkDuration: Double = 0.2) {
-    self.streamFormat = format
-    self.targetChunkDuration = chunkDuration
+    
+    // Pre-calculate chunk parameters
+    let bytesPerFrame = Int(format.mBytesPerFrame)
+    let samplesPerChunk = Int(format.mSampleRate * chunkDuration)
+    self.bytesPerChunk = samplesPerChunk * bytesPerFrame
+    self.chunkDuration = Double(samplesPerChunk) / format.mSampleRate
+
+    // Calculate max buffer size to hold ~10 seconds of audio, way more than the maximum we allow
+    let bytesPerSecond = Int(format.mSampleRate) * bytesPerFrame
+    self.maxBufferSize = bytesPerSecond * 10
+    
+    // Pre-allocate ring buffer
+    self.buffer = Array(repeating: 0, count: maxBufferSize)
   }
 
   public func append(_ data: Data) {
-    buffer.append(data)
+    guard availableBytes + data.count <= maxBufferSize else {
+      Logger.error("Audio buffer overflow", context: [
+        "requested": String(data.count),
+        "available": String(maxBufferSize - availableBytes)
+      ])
+      return
+    }
+    
+    // Simple, clean, fast enough
+    for byte in data {
+      buffer[writeIndex] = byte
+      writeIndex = (writeIndex + 1) % maxBufferSize
+    }
+    
+    availableBytes += data.count
   }
 
   public func processChunks() -> [AudioPacket] {
@@ -26,36 +57,48 @@ public class AudioBuffer {
   }
 
   public func flushRemaining() -> AudioPacket? {
-    guard !buffer.isEmpty else { return nil }
+    guard availableBytes > 0 else { return nil }
+
+    // Create Data from remaining bytes
+    var remainingData = Data(capacity: availableBytes)
+    for _ in 0..<availableBytes {
+      remainingData.append(buffer[readIndex])
+      readIndex = (readIndex + 1) % maxBufferSize
+    }
+    
+    availableBytes = 0
 
     let packet = AudioPacket(
       timestamp: Date(),
       duration: 0.0,  // Unknown duration for final chunk
       peakAmplitude: 0.0,
-      rawAudioData: buffer
+      rawAudioData: remainingData
     )
 
-    buffer.removeAll()
     return packet
   }
 
   private func nextChunk() -> AudioPacket? {
-    let bytesPerFrame = Int(streamFormat.mBytesPerFrame)
-    let samplesPerChunk = Int(streamFormat.mSampleRate * targetChunkDuration)
-    let bytesPerChunk = samplesPerChunk * bytesPerFrame
+    // Check if we have enough data for a complete chunk
+    guard availableBytes >= bytesPerChunk else { return nil }
 
-    guard buffer.count >= bytesPerChunk else { return nil }
-
-    let chunkData = buffer.prefix(bytesPerChunk)
+    // Extract chunk data - bounds-checked but still efficient
+    var chunkData = Data(capacity: bytesPerChunk)
+    
+    for _ in 0..<bytesPerChunk {
+      chunkData.append(buffer[readIndex])
+      readIndex = (readIndex + 1) % maxBufferSize
+    }
+    
+    availableBytes -= bytesPerChunk
 
     let packet = AudioPacket(
       timestamp: Date(),
-      duration: Double(samplesPerChunk) / streamFormat.mSampleRate,
+      duration: chunkDuration,
       peakAmplitude: 0.0,  // No analysis in raw mode
-      rawAudioData: Data(chunkData)
+      rawAudioData: chunkData
     )
 
-    buffer.removeFirst(bytesPerChunk)
     return packet
   }
 }

--- a/Sources/Core/AudioRecorder.swift
+++ b/Sources/Core/AudioRecorder.swift
@@ -75,6 +75,7 @@ public class AudioRecorder {
   }
 
   // FIXME: note to self, what about installTap? Would require audio engine and a node?
+  // No; AudioEngine.installTap() can only fire as often as 100ms. too slow for us
   private func setupAndStartIOProc() {
     Logger.debug("Creating IO proc")
     var status = AudioDeviceCreateIOProcID(

--- a/Sources/Core/AudioRecorder.swift
+++ b/Sources/Core/AudioRecorder.swift
@@ -74,7 +74,7 @@ public class AudioRecorder {
     Logger.info("Audio device started successfully")
   }
 
-  // FIXME: note to self, what about installTap? Would require audio engine and a node?
+  // Note to self, what about installTap? Would require audio engine and a node?
   // No; AudioEngine.installTap() can only fire as often as 100ms. too slow for us
   private func setupAndStartIOProc() {
     Logger.debug("Creating IO proc")
@@ -127,8 +127,8 @@ public class AudioRecorder {
 
   func stopRecording() {
     // Send any remaining buffered audio, applying conversion if needed
-    if let finalPacket = audioBuffer?.flushRemaining() {
-      let processedPacket = converter?.transform(finalPacket) ?? finalPacket
+    audioBuffer?.processChunks().forEach { packet in
+      let processedPacket = converter?.transform(packet) ?? packet
       outputHandler.handleAudioPacket(processedPacket)
     }
 

--- a/Sources/Core/AudioTeeErrors.swift
+++ b/Sources/Core/AudioTeeErrors.swift
@@ -8,6 +8,7 @@ public enum AudioTeeError: Error {
   case aggregateDeviceCreationFailed(OSStatus)
   case tapAssignmentFailed(OSStatus)
   case pidTranslationFailed([Int32])
+  case bufferOverflow(requested: Int, available: Int)
 }
 
 // MARK: - Audio Format Conversion Errors

--- a/Sources/Core/AudioTeeErrors.swift
+++ b/Sources/Core/AudioTeeErrors.swift
@@ -8,7 +8,6 @@ public enum AudioTeeError: Error {
   case aggregateDeviceCreationFailed(OSStatus)
   case tapAssignmentFailed(OSStatus)
   case pidTranslationFailed([Int32])
-  case bufferOverflow(requested: Int, available: Int)
 }
 
 // MARK: - Audio Format Conversion Errors


### PR DESCRIPTION
Previous use of a `Data` struct (which wraps an underlying buffer of bytes) to store the current audio buffer in conjunction with `buffer.removeFirst()` caused linear memory growth, since the latter doesn't actually shrink the internal buffer or move the remaining data to the beginning.

Switch instead to a manually managed ring buffer with fixed memory overhead.