### PR TITLE
Add --flush option to reduce stdout buffering latency

### DIFF
--- a/Sources/CLI/AudioTee.swift
+++ b/Sources/CLI/AudioTee.swift
@@ -8,6 +8,7 @@ struct AudioTee {
   var stereo: Bool = false
   var sampleRate: Double?
   var chunkDuration: Double = 0.2
+  var flush: Bool = false
 
   init() {}
 
@@ -31,6 +32,7 @@ struct AudioTee {
           audiotee --include-processes 1234 5678 9012  # Tap only these processes
           audiotee --exclude-processes 1234 5678       # Tap everything except these
           audiotee --mute                       # Mute processes being tapped
+          audiotee --flush                      # Flush stdout after each chunk
         """
     )
 
@@ -42,6 +44,7 @@ struct AudioTee {
       name: "exclude-processes", help: "Process IDs to exclude (space-separated)")
     parser.addFlag(name: "mute", help: "Mute processes being tapped")
     parser.addFlag(name: "stereo", help: "Records in stereo")
+    parser.addFlag(name: "flush", help: "Flush stdout after each audio chunk (reduces latency when piping)")
     parser.addOption(
       name: "sample-rate",
       help: "Target sample rate (8000, 16000, 22050, 24000, 32000, 44100, 48000)")
@@ -59,6 +62,7 @@ struct AudioTee {
       audioTee.excludeProcesses = try parser.getArrayValue("exclude-processes", as: Int32.self)
       audioTee.mute = parser.getFlag("mute")
       audioTee.stereo = parser.getFlag("stereo")
+      audioTee.flush = parser.getFlag("flush")
       audioTee.sampleRate = try parser.getOptionalValue("sample-rate", as: Double.self)
       audioTee.chunkDuration = try parser.getValue("chunk-duration", as: Double.self)
 
@@ -136,7 +140,7 @@ struct AudioTee {
       throw ExitCode.failure
     }
 
-    let outputHandler = BinaryAudioOutputHandler()
+    let outputHandler = BinaryAudioOutputHandler(flushAfterWrite: flush)
     let recorder = AudioRecorder(
       deviceID: deviceID, outputHandler: outputHandler, convertToSampleRate: sampleRate,
       chunkDuration: chunkDuration)

--- a/Sources/Output/Handlers/BinaryOutputHandler.swift
+++ b/Sources/Output/Handlers/BinaryOutputHandler.swift
@@ -1,10 +1,18 @@
 import Foundation
 
 public class BinaryAudioOutputHandler: AudioOutputHandler {
+  private let flushAfterWrite: Bool
+
+  public init(flushAfterWrite: Bool = false) {
+    self.flushAfterWrite = flushAfterWrite
+  }
+
   public func handleAudioPacket(_ packet: AudioPacket) {
-    // TODO: should we use a DispatchQueue instead of writing directly?
     // Write raw binary audio data directly to stdout
     FileHandle.standardOutput.write(packet.data)
+    if flushAfterWrite {
+      fflush(stdout)
+    }
   }
 
   public func handleMetadata(_ metadata: AudioStreamMetadata) {


### PR DESCRIPTION
(AI-generated description, natch, but I think it covers it well. My use case is AEC and the ~50ms delay causes alignment headaches between reference audio from audiotee and what the mic is picking up)

# PR Title

Add `--flush` option to reduce stdout buffering latency

# PR Description

## Summary

- Adds a `--flush` CLI flag that flushes stdout after each audio chunk write
- Fixes latency issues when piping AudioTee output to a parent process

## Problem

When stdout is connected to a pipe (common when spawning AudioTee from Node.js, Python, etc.), the OS uses **block buffering** (typically 4KB-64KB). Since AudioTee writes 960-byte chunks (10ms at 48kHz s16le mono), 4-7 chunks accumulate before the buffer flushes, causing **40-70ms bursts** instead of steady 10ms delivery.

This is problematic for real-time applications like:
- **AEC (Acoustic Echo Cancellation)** that rely on consistent timing between reference and capture signals
- **Real-time ASR** where latency spikes affect transcription timing
- **Audio visualization** where smooth updates are expected

## Solution

Add `fflush(stdout)` after each `FileHandle.standardOutput.write()` call when the `--flush` flag is enabled.

## Changes

- `Sources/Output/Handlers/BinaryOutputHandler.swift`: Add `flushAfterWrite` parameter to init, call `fflush(stdout)` when enabled
- `Sources/CLI/AudioTee.swift`: Add `--flush` flag, pass to `BinaryAudioOutputHandler`

## Usage

```shell
# Enable flushing for real-time applications
./audiotee --flush | your_audio_processor

# Combine with other options
./audiotee --sample-rate 48000 --flush | node audio-processor.js
```

## Tradeoffs

- (+) Enables real-time chunk delivery when piping
- (+) Backward compatible - default behavior unchanged
- (-) Slightly higher CPU overhead due to syscalls on each chunk (negligible for most use cases)

## Testing

Tested by spawning AudioTee from Node.js and measuring inter-chunk timing:
- Without `--flush`: 40-70ms gaps between chunk arrivals
- With `--flush`: Consistent ~10ms gaps matching chunk duration
